### PR TITLE
skip webpack compile if no change to app/javascript/ directory

### DIFF
--- a/lib/mina/webpacker/tasks.rb
+++ b/lib/mina/webpacker/tasks.rb
@@ -1,7 +1,13 @@
+set :webpack_dirs, ['app/javascript/']
+
 namespace :webpacker do
-  desc "Compile webpack assets"
+  desc 'Compile webpack assets'
   task compile: :environment do
-    comment %{Compiling webpack assets}
-    command %{#{fetch(:rails)} webpacker:compile}
+    command check_for_changes_script(
+      at: fetch(:webpack_dirs),
+      skip: %{echo "-----> Skipping webpacker compile"},
+      changed: %{echo "-----> Compiling webpack assets"
+      #{echo_cmd "#{fetch(:rake)} webpacker:compile"}}
+    ), quiet: true
   end
 end

--- a/lib/mina/webpacker/tasks.rb
+++ b/lib/mina/webpacker/tasks.rb
@@ -7,6 +7,7 @@ namespace :webpacker do
       at: fetch(:webpack_dirs),
       skip: %{echo "-----> Skipping webpacker compile"},
       changed: %{echo "-----> Compiling webpack assets"
+      #{echo_cmd "yarn"}
       #{echo_cmd "#{fetch(:rake)} webpacker:compile"}}
     ), quiet: true
   end

--- a/lib/mina/webpacker/tasks.rb
+++ b/lib/mina/webpacker/tasks.rb
@@ -2,7 +2,7 @@ set :webpack_dirs, ['app/javascript/']
 
 namespace :webpacker do
   desc 'Compile webpack assets'
-  task compile: :environment do
+  task :compile do
     command check_for_changes_script(
       at: fetch(:webpack_dirs),
       skip: %{echo "-----> Skipping webpacker compile"},

--- a/lib/mina/webpacker/version.rb
+++ b/lib/mina/webpacker/version.rb
@@ -1,5 +1,5 @@
 module Mina
   module Webpacker
-    VERSION = "0.1.0"
+    VERSION = "0.2.0"
   end
 end


### PR DESCRIPTION
Similar to how `mina` skips asset precompilation if no changes were detected (see https://github.com/mina-deploy/mina/blob/33a5f61d81d7d95aac569d1bbc3d66fd91a35208/tasks/mina/rails.rb#L68), this change would do the same with webpack assets.